### PR TITLE
Update .vscode/settings.json

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -10,5 +10,6 @@
   "eslint.nodePath": ".yarn/sdks",
   "prettier.prettierPath": ".yarn/sdks/prettier/index.js",
   "typescript.enablePromptUseWorkspaceTsdk": true,
-  "files.eol": "\n"
+  "files.eol": "\n",
+  "editor.rulers": [80]
 }


### PR DESCRIPTION
Because 80 char ruler can be displayed for consistent comment length