### PR TITLE
Remove excludes from tsconfig

### DIFF
--- a/common-api/tsconfig.json
+++ b/common-api/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "extends": "@tsconfig/node16/tsconfig.json",
   "include": ["./src/**/*"],
-  "exclude": ["**/*.test.ts"],
   "compilerOptions": {
     "outDir": "build",
     "sourceMap": true,

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "extends": "@tsconfig/node16/tsconfig.json",
   "include": ["./src/**/*"],
-  "exclude": ["**/*.test.ts"],
   "compilerOptions": {
     "outDir": "build",
     "sourceMap": true,


### PR DESCRIPTION
Because VSCode relies on include path to parse files, excluding tests
creates typing problems in editor