### PR TITLE
Enable poker-room name, creatorId prefix search

### DIFF
--- a/server/src/controllers/poker-rooms/getAll.test.ts
+++ b/server/src/controllers/poker-rooms/getAll.test.ts
@@ -3,7 +3,7 @@ import { flop, playersSeated } from "@pokester/poker-engine-fixtures/table";
 import { Types } from "mongoose";
 import RegistrationExtension from "../../middleware/request-extensions/RegistrationExtension";
 import PokerRoom from "../../models/PokerRoom/index";
-import getAll from "./getAll";
+import getAll, { prefixMatchQueryOp } from "./getAll";
 
 const username = "usernameValue";
 jest
@@ -64,7 +64,9 @@ describe("succeeds", () => {
     expect(mockFind).toHaveBeenCalledTimes(1);
     expect(mockFind).toHaveBeenCalledWith();
     expect(mockFindWhere).toHaveBeenCalledTimes(1);
-    expect(mockFindWhere).toHaveBeenCalledWith(query);
+    expect(mockFindWhere).toHaveBeenCalledWith({
+      creatorId: prefixMatchQueryOp(query.creatorId),
+    });
     expect(mockFindSelect).toHaveBeenCalledTimes(1);
     expect(mockFindSelect).toHaveBeenCalledWith({
       name: 1,
@@ -92,7 +94,9 @@ describe("succeeds", () => {
     expect(mockFind).toHaveBeenCalledTimes(1);
     expect(mockFind).toHaveBeenCalledWith();
     expect(mockFindWhere).toHaveBeenCalledTimes(1);
-    expect(mockFindWhere).toHaveBeenCalledWith(query);
+    expect(mockFindWhere).toHaveBeenCalledWith({
+      name: prefixMatchQueryOp(query.name),
+    });
     expect(mockFindSelect).toHaveBeenCalledTimes(1);
     expect(mockFindSelect).toHaveBeenCalledWith({
       name: 1,

--- a/server/src/controllers/poker-rooms/getAll.ts
+++ b/server/src/controllers/poker-rooms/getAll.ts
@@ -5,6 +5,17 @@ import PokerRoom from "../../models/PokerRoom/index";
 
 export { ReqQuery, ResBody };
 
+const escapeEmbeddedRegExpStr = (str: string) =>
+  str.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+
+/**
+ * Given a string, returns a query operator for prefix matching based on the
+ * given string.
+ */
+export const prefixMatchQueryOp = (str: string) => ({
+  $regex: new RegExp(`^${escapeEmbeddedRegExpStr(str)}`),
+});
+
 /**
  * Given an HTTP request to get PokerRooms (including optional filters),
  * an HTTP response, and a callback, attempts to respond with a JSON
@@ -35,10 +46,14 @@ export const getAll: RequestHandler<
 
     const mutablePokerRoomsQuery = PokerRoom.find();
     if (name) {
-      mutablePokerRoomsQuery.where({ name });
+      mutablePokerRoomsQuery.where({
+        name: prefixMatchQueryOp(name),
+      });
     }
     if (creatorId) {
-      mutablePokerRoomsQuery.where({ creatorId });
+      mutablePokerRoomsQuery.where({
+        creatorId: prefixMatchQueryOp(creatorId),
+      });
     }
     if (canSit && ["false", "true"].includes(canSit)) {
       mutablePokerRoomsQuery.byCanPlayerSit(username, canSit === "true");


### PR DESCRIPTION
* Update getAll

To use prefix based regexp for creatorId, name query strings to allow for better matches