### PR TITLE
Update QsSearch

### DIFF
--- a/client/src/components/utils/QsSearch.tsx
+++ b/client/src/components/utils/QsSearch.tsx
@@ -1,7 +1,7 @@
 import TextField from "@mui/material/TextField";
 import debounce from "lodash/debounce";
 import { ParsedQs } from "qs";
-import React, { FC, useCallback, useMemo, useState } from "react";
+import React, { FC, useCallback, useEffect, useMemo, useState } from "react";
 import useValidQsState, {
   IsValidParsedQsValue,
 } from "../../hooks/qs/useValidQsState";
@@ -60,6 +60,8 @@ const QsSearch: FC<QsSearchProps> = ({
 
   const qsValue = partialQsValue || "";
   const [inputValue, setInputValue] = useState<string>(qsValue);
+
+  useEffect(() => setInputValue(qsValue), [setInputValue, qsValue]);
 
   const handleChange = useCallback(
     (event: React.ChangeEvent<HTMLInputElement>) => {


### PR DESCRIPTION
Because there was a bug where displayed value would remain static when query string in URL bar mutated. Fix was to useEffect that mutates input value when qsValue changes.