### PR TITLE
Update PlayingCard

### DIFF
--- a/client/src/components/room/playing-card/PlayingCard.tsx
+++ b/client/src/components/room/playing-card/PlayingCard.tsx
@@ -82,7 +82,7 @@ const VisiblePlayingCard: FC<VisiblePlayingCardProps> = ({
   containerRef,
   dealt,
 }) => {
-  const [transitionIn, setTransitionIn] = useState(true);
+  const [transitionIn, setTransitionIn] = useState(false);
   useEffect(() => {
     setTransitionIn(false);
     setTimeout(() => setTransitionIn(true), 1);


### PR DESCRIPTION
Because initial value of transition would cause immedate toggle due to effect immediately running afterwards.